### PR TITLE
Change environment to use VSCode development containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,12 @@
 FROM devkitpro/devkitppc:latest
 
 ENV PATH="/opt/zig:${PATH}"
-ENV ZIG_VERSION="951+9e2472706"
+ENV ZIG_VERSION="0.9.0-dev.951+9e2472706"
 ENV ZLS_SHA="c541479"
 
 # Install zig
 RUN mkdir /opt/zig && mkdir /opt/zls && \
-	curl -L https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.$ZIG_VERSION.tar.xz | tar -xJ --strip-components=1 -C /opt/zig && \
+	curl -L https://ziglang.org/builds/zig-linux-x86_64-$ZIG_VERSION.tar.xz | tar -xJ --strip-components=1 -C /opt/zig && \
 	git clone --recurse-submodules https://github.com/zigtools/zls /opt/zls && \
 	cd /opt/zls && \
 	git reset --hard $ZLS_SHA && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM devkitpro/devkitppc:latest
+
+ENV PATH="/opt/zig:${PATH}"
+ENV ZIG_VERSION="951+9e2472706"
+ENV ZLS_SHA="c541479"
+
+# Install zig
+RUN mkdir /opt/zig && mkdir /opt/zls && \
+	curl -L https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.$ZIG_VERSION.tar.xz | tar -xJ --strip-components=1 -C /opt/zig && \
+	git clone --recurse-submodules https://github.com/zigtools/zls /opt/zls && \
+	cd /opt/zls && \
+	git reset --hard $ZLS_SHA && \
+	zig build -Drelease-safe
+
+# Entrypoint
+ENTRYPOINT /bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "WiiZig",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"zigLanguageClient.path": "/opt/zls/zig-out/bin/zls"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"tiehuis.zig",
+		"augusterame.zls-vscode",
+		"prime31.zig"
+	],
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-.*
-/*.dol
-/*.elf
 /build
 /zig-cache

--- a/build.zig
+++ b/build.zig
@@ -17,8 +17,8 @@ pub fn build(b: *Builder) void {
         .cpu_features_add = std.Target.powerpc.featureSet(&.{.hard_float}),
     });
 
-    const elf = b.addSystemCommand(&[_][]const u8{ "docker-compose", "run", "devkitpro", "/opt/devkitpro/devkitPPC/bin/powerpc-eabi-gcc", "build/main.o", "-g", "-DGEKKO", "-mrvl", "-mcpu=750", "-meabi", "-mhard-float", "-Wl,-Map,.map", "-L/opt/devkitpro/libogc/lib/wii", "-lwiiuse", "-lbte", "-logc", "-lm", "-o", "zig-wii.elf" });
-    const dol = b.addSystemCommand(&[_][]const u8{ "docker-compose", "run", "devkitpro", "elf2dol", "zig-wii.elf", "zig-wii.dol" });
+    const elf = b.addSystemCommand(&[_][]const u8{ "/opt/devkitpro/devkitPPC/bin/powerpc-eabi-gcc", "build/main.o", "-g", "-DGEKKO", "-mrvl", "-mcpu=750", "-meabi", "-mhard-float", "-Wl,-Map,build/.map", "-L/opt/devkitpro/libogc/lib/wii", "-lwiiuse", "-lbte", "-logc", "-lm", "-o", "build/zig-wii.elf" });
+    const dol = b.addSystemCommand(&[_][]const u8{ "elf2dol", "build/zig-wii.elf", "build/zig-wii.dol" });
     b.default_step.dependOn(&dol.step);
     dol.step.dependOn(&elf.step);
     elf.step.dependOn(&obj.step);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3.1'
-
-services:
-  devkitpro:
-    image: devkitpro/devkitppc:latest
-    command: make
-    working_dir: /app
-    volumes:
-      - '.:/app'

--- a/zig-wii.code-workspace
+++ b/zig-wii.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
This PR moves the zig-wii development environment into a VSCode development container.
Opening the workspace in vscode will ask you to re-open the workspace inside the container.
From here on, everything works as if you're developing locally, without requiring docker compose to spin up the container for the link and conversion steps.

The container comes with Zig and ZLS pre installed. The versions for both can be changed through the provided environmental variables in the Dockerfile.

I've also updated the builder to output the `.map` `.dol` and `.elf` files into the `build` folder.